### PR TITLE
Fix the link of llm dev landscape in README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Report 2.0**
 🌐️ [English Report](/reports/250913_llm_landscape/250913_llm_report_en.md) | [中文报告](/reports/250913_llm_landscape/250913_llm_report_cn.md)
 
-![LLM Development Landscape](/reports/250913_llm_landscape/figures/large_models_landscape.png)
+![LLM Development Landscape](/reports/250913_llm_landscape/figures/llm_development_landscape.png)
 
 **Online Interactive Version:** https://antoss-landscape.my.canva.site
 


### PR DESCRIPTION
The alt text shows it should be llm_development_landscape.png,  but the link of the model picture was put here

## Summary by Sourcery

Documentation:
- Update README image link for LLM Development Landscape to use llm_development_landscape.png