### PR TITLE
fix: typo in 0527 report

### DIFF
--- a/reports/250527_llm_landscape/250527_llm_report_cn.md
+++ b/reports/250527_llm_landscape/250527_llm_report_cn.md
@@ -32,11 +32,11 @@
 
 最终，呈现下面这张 **<font style="color:rgb(28, 30, 33);">2025 年大模型开源开发生态全景图，</font>**<font style="color:rgb(28, 30, 33);">截止 2025 年 5 月发布时，全景图上收录了 </font>**<font style="color:rgba(253,58,184,1);">135 </font>**<font style="color:rgb(28, 30, 33);">个项目，涵盖了</font>智能体应用层和模型基础设施层一共 **<font style="color:rgba(253,58,184,1);">19</font>** 个技术领域。虽然我们非常努力想从中挖掘更多信息，但我们也完全明白，社区的数据既不全面也不完全准确，而且也不一定能反映出很多最新最优秀的技术变化，我们只希望这个报告能给大家一些有益的参考，有什么错漏之处和其他值得补充的观点，也欢迎大家反馈给我们。
 
-![地址： https://antoss-landscape.my.canva.site](/figures/2.png)
+![地址： https://antoss-landscape.my.canva.site](./figures/2.png)
 
 
 
-以下是本次全景图上所有项目中，在 **2025 年 OpenRank 排名 Top 20 **的项目详情：
+以下是本次全景图上所有项目中，在 **2025 年 OpenRank 排名 Top 20**的项目详情：
 
 ![](./figures/3_CN.png)
 
@@ -140,7 +140,7 @@ LLM 浪潮同时催生了一批 “速生速死” 的 AI 项目和产品。在 
 
 
 
-![OpenRank Top 10 项目排名变化](/figures/12.gif)
+![OpenRank Top 10 项目排名变化](./figures/12.gif)
 
 
 

--- a/reports/250527_llm_landscape/250527_llm_report_en.md
+++ b/reports/250527_llm_landscape/250527_llm_report_en.md
@@ -5,7 +5,7 @@
 ![](./figures/1.png)
 
 ## The LLM Development Ecosystem: A Snapshot
-![https://antoss-landscape.my.canva.site](/figures/2.png)
+![https://antoss-landscape.my.canva.site](./figures/2.png)
 
 
 


### PR DESCRIPTION
Fix some typo in 0527 repo

## Summary by Sourcery

Fix image links and minor typos in the 0527 LLM landscape reports

Documentation:
- Correct figure image references to use local relative paths in both Chinese and English reports
- Adjust bold formatting by removing extra spacing around “Top 20” in the Chinese report