### PR TITLE
Update developer profiles and agentic AI article

### DIFF
--- a/insights/260527-agentic_landscape/260527_agentic_ai_en.md
+++ b/insights/260527-agentic_landscape/260527_agentic_ai_en.md
@@ -1,12 +1,8 @@
 # Agentic AI 2026: When the Hackathon Fever Cools Down
 
-> English translation. Simple, direct, and readable technical commentary style.
-> Original Chinese article: https://yuque.antfin.com/ospo/landscape/fu3wdazkigm69cbd
-
 Subtitle: After the party cools down, we still want an inclusive AGI that more people can use.
 
 ## Opening
-
 Over the past year, we often described the LLM developer ecosystem as a “hackathon in the real world.” The phrase fits. It has energy, speed, luck, and flashes of talent. It also has noise, repeated work, short-lived projects, and repos that become famous overnight only to be covered by the next wave a few days later.
 
 By mid-2026, the feeling is different. The change is no longer just “a few more Agent projects.” Something deeper is shifting: the way software is made is starting to move.
@@ -16,31 +12,25 @@ In the past, people used software. Software was designed around human hands, eye
 So the most useful question is not whether Agentic AI has a bubble. Of course it does, and it will have more. The better questions are: when the hackathon fever cools down, where will software go? What will developers become? What role is left for open source? And why do we need an inclusive AGI future?
 
 ## Signals From Platforms
-
 Subtitle: Models have not made software smaller. They have widened its boundary.
 
 If we only watch product launches, it is easy to think that models are the whole story of AI. But when we look at GitHub and Hugging Face together, a different picture appears.
 
 GitHub tells us what developers are building. Octoverse 2025 shows that GitHub has more than 180 million developers. In 2025, it added more than 36 million new developers, about one new developer every second. From January to April 2026, OpenDigger events recorded 13.016 million active developers and 27.107 million active repositories. Software production has not shrunk because models got stronger. It is still expanding.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720895964-829b19bb-a280-46a4-b36e-86a784455a04.png)
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720954391-ba5bb9c2-7c6d-46a7-9dc0-448ba31491fe.png)
 
 The more interesting signal is automated accounts. In the first four months of 2017, only 112 bot or app actors were active in the GitHub event stream. In the same period in 2026, the number reached 17,285. That is 154 times larger across the ten-year window. The first four months of 2026 alone already doubled the same period in 2025. Today, open-source collaboration can no longer be imagined as “human developers working on GitHub, with a few CI bots doing chores on the side.” Automated accounts are entering the software production chain. They are becoming part of the collaboration network.
 
 Hugging Face gives another signal. It shows how models are published, downloaded, changed, and reproduced. The number of public models has reached 2 million. It grew by more than 100% in the past year, and more than 540,000 models were added by May 2026 alone. A model platform is no longer just a display case for research models. It looks more like a busy factory. Some people publish foundation models. Some fine-tune them. Some quantize them. Some convert formats. Some upload adapters. Some move the same capability to different devices and runtime environments.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720906663-cafecdf7-7908-4fc3-9cac-4c0b86bc4533.png)
 
 The GitHub collaboration list and star-growth list tell a similar story. AI projects have entered the core engineering world. Developer attention and curiosity are strongly focused on repos around new words like **Agent, Claude Code, and Skills**. But real collaboration still happens around the long-term foundations and complex systems of software. In other words, models have not eaten software. They are rewriting the division of labor inside software.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779698368777-fbcaad88-925d-456b-8411-35477744fef7.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781626242321-9b3fe921-865f-44ec-b9cb-847d2dbc71ba.png)
 
 Models handle understanding, generation, reasoning, and tool use. Software puts models into reliable workflows. It manages data, permissions, state, cost, audit, and delivery. The closer models get to real work, the more software is needed to define boundaries, save process, connect systems, and handle failure. Models have not made software smaller. They have widened its boundary.
 
 ## The Agentic AI Ecosystem Architecture
-
 Subtitle: The ecosystem has moved from an LLM toolchain to a full execution stack for Agentic AI.
 
 When we built the LLM developer landscape last year, the main question was still: which projects should be on the map? At that time, the ecosystem was slowly forming layers around LLM SDKs, RAG, agent frameworks, application platforms, and inference infrastructure. People cared about how to connect models, build RAG, write an agent, and run inference services.
@@ -53,32 +43,28 @@ Projects appear too fast, and attention moves too fast. A static map can easily 
 
 This dynamic leaderboard, built with OpenDigger, is now live on the inclusionAI website: [https://www.inclusion-ai.org/insight](https://www.inclusion-ai.org/insight)
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779761050301-499c5d17-5248-45d0-9797-8b6db7f7f653.png)
+
 
 The latest monthly OpenRank Top 10 looks like a cross-section of the ecosystem. Claude Code, Codex, OpenCode, and Gemini CLI sit near the task-entry layer. vLLM, SGLang, TensorRT-LLM, and PyTorch sit near the infrastructure layer. Entry projects are closer to developers and users, so issues and PRs are busier. Infrastructure projects may have less scattered participation, but the collaboration density is high. What is heating up is not a single entry point. It is the whole execution system.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779698508499-b13be9cf-5841-48e6-bab6-1f82f96f9d38.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781626872164-64ba4a1b-5d35-4e72-bdb9-b7334c62a749.png)
 
 The structural change is clear. In 2025, the landscape was still sorting SDKs, RAG, ChatUI, and MLOps. In 2026, leading projects are being rearranged around the task execution system of agents.
 
 The landscape from last May still felt very much like an LLM toolchain. We were mostly looking at which SDK to use for LLM apps, which RAG and vector database to connect data, and which inference framework to run models. By May 2026, the focus had moved from “how to write an agent” to “how agents enter task execution.”
 
 This makes the three-layer architecture of Agentic AI in 2026 easier to read. At the top are human-agent collaboration and task entry. In the middle are token supply and scheduling. At the bottom are the model capabilities themselves.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779695655418-7dd2da15-082a-4aea-bd41-b6a0d40383b0.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781626897022-7efdfecd-3383-4150-aa17-b05f4a4e4685.png)
 
 **Agent Infra decides who AI can work for.** It includes the entry points users meet directly, such as coding agents. It also includes agent runtime infrastructure, such as context, tool use, sandbox, and AgentOps. It also includes agent builders, orchestrators, and operators.
 
 **Model Infra decides whether this can scale.** It includes data, training, inference serving, deployment, scheduling, and operations. If an agent only answers one sentence, the lower-level cost can be ignored. But once it reads code, searches information, calls tools, waits for feedback, and keeps going, tokens stop being chat consumption. They become production material.
 
 **Models decide where the capability boundary is.** The model layer still matters. But it can no longer be understood only by asking who has the higher benchmark. Frontier and foundation models explore the upper bound. Small edge models solve low-cost, low-latency, and privacy-heavy cases. Specialized models adapt to code, finance, and services. Real tasks will look more like model portfolios than one model ruling everything.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779700166932-08ce0e3b-5e70-486f-b295-fe51851ee0cd.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781626334720-d00ba4ec-c0d8-4011-be48-3fe06d3381d6.png)
 
 These three layers are not a simple supply chain. They push one another forward. When agents try to do longer tasks, Model Infra is forced to lower inference cost, increase context throughput, and improve observability. When Model Infra improves, small models and specialized models become easier to use in production. When the model layer improves in reasoning, tool use, and multimodality, agents are pushed further out of the chat box.
 
 ### Agent Infra: Redefining How Software Is Used
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779696979129-1cd6407f-f2f7-4f14-9976-652711dfb640.png)
 
 Agent Infra is the busiest layer in this dataset, and also the easiest to misread. On the surface, products like OpenClaw, Claude Code, and Codex are fighting for attention. Deeper down, this layer is redefining how software is used. **Agent Infra is bringing silicon-based executors into the software world.**
@@ -91,20 +77,17 @@ An agent without context is only briefly awake. Without tools, it can only give 
 
 Software is being repackaged as a runtime environment that agents can enter. APIs, MCP, tool protocols, context, sandbox, and observability are becoming new basic parts.
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779703575332-dc5b80cc-969f-436f-ba44-ca837cfa44b4.png)
+
 
 We gave the descriptions and READMEs of 226 projects to a model and built a multi-label classification. The result is telling. Coding Agent has 78 projects and 14,019 participants. MCP has 59 projects and 6,651 participants. Memory has 70 projects and 7,609 participants. Observability has 71 projects and 5,463 participants. Gateway has 31 projects and 2,637 participants. These labels overlap, so we should not add them up. But the horizontal view is enough: attention is moving from “building a product that can chat or write code” to putting context, tools, gateways, sandboxes, and observability into a runtime.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779697006202-435a1ffd-f5b7-4fb5-a677-bbeb8a8858bb.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627001378-a8180e8c-04fe-4416-a876-5a749f2985a8.png)
 
 ### Model Infra: The Main Job Is Supplying Tokens at Scale
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779712767923-69789186-1671-4579-bdc8-110dd1bb4592.png)
 
 The inference layer is splitting into several jobs. High-throughput engines such as vLLM and SGLang run models faster, more reliably, and more cheaply. Edge and local inference projects such as llama.cpp bring models to personal computers, private environments, and edge devices. Data-center schedulers such as Dynamo and Ray Serve handle multi-model, multi-tenant, multi-GPU, and multi-region operation. Gateways and proxies such as LiteLLM and OpenRouter handle model routing, fallback, unified interfaces, cost tracking, and audit.
 
 Post-training is another key part of this layer. Projects like AReaL and Slime show the rise of reasoning training and Agentic RL. In the agent era, RL is not only about making models answer better. It is also about making them better at using tools, following constraints, keeping state in long tasks, and knowing when to stop and ask a human.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779701213412-d0f9704a-adef-4314-8e29-3314de43d592.png)
 
 **The future cost advantage of AI will not come only from cheaper models. It will also come from better token supply-chain management.** The value of Model Infra is to orchestrate these capabilities like electricity, logistics, and databases. Whoever can make tokens stable, cheap, observable, and governable will own a real production infrastructure in the agent era.
@@ -120,78 +103,74 @@ Dynamo [issue #5506](https://github.com/ai-dynamo/dynamo/issues/5506), the H1 20
 Another issue, [SGLang issue #20252](https://github.com/sgl-project/sglang/issues/20252), records a very real large-scale deployment failure: qwen3-32b-fp8, with 90 prefill and 30 decode workers, running on an H20 cluster. After some prefill nodes restarted or migrated, decode kept retrying, health checks failed, the router removed workers, traffic moved to the remaining nodes, and under high QPS the system ended in cascading failures and 503s. The lesson is simple: running the model is only the first step. The harder industrial problem is whether a single node’s instability will be amplified by routing, health checks, and traffic shifting into a global failure. **In production, the real pain is stability.**
 
 ### Model: There Is No Single Winner
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779712750944-8ce1ee65-5c6a-4b09-ad3b-18e924df5569.png)
 
 The model layer is still the source of capability for the whole ecosystem. But it can no longer be understood by asking only who has more parameters or a higher benchmark.
 
 Hugging Face derivative and download data reminds us that a model’s life does not stop at release. Model families such as Qwen and Gemma matter not only because the models are strong, but also because people fine-tune them, quantize them, convert them, distill them, and move them to edge devices and application scenarios. Models are starting to have downstream ecosystems like open-source software packages: people fork them, patch them, make lightweight versions, build domain versions, and create compatibility layers.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779765659901-21dcc08f-e229-495f-a0b9-cba9f6d30a31.png)
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779765667139-3abbc1ff-1d25-4791-8235-c25d346581ba.png)
 
 _Hugging Face shows signals of model release, download, and reproduction._
 
 OpenRouter’s token usage leaderboard breaks the story of a single champion model. Coding may use one model. Long-context research may use another. Low-cost batch processing may use another. Voice, image, and video may use others. Local privacy scenarios may need a different stack again. Real usage is unlikely to settle on one permanent winner. Users route across price, speed, context length, tool use, coding ability, and free quotas.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779765696990-0f083d10-e2ad-4395-82c5-0dac85dbf216.png)
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779765707342-dd5f3beb-ca58-4a88-9e4d-e5c1e2ec92e9.png)
 
 _Real token usage shows the reality of many models, many providers, and many routes._
 
 This view is already supported by research and engineering practice. [RouteLLM](https://arxiv.org/abs/2406.18665), from ICLR 2025, runs a clear comparison: first judge the difficulty of the request, then decide whether to use a strong model or a cheaper model, instead of sending every request to the most expensive model. On some benchmarks, this routing approach keeps quality close to the strong model while cutting cost to less than half. [IPR](https://aclanthology.org/2025.emnlp-industry.170/), from EMNLP Industry 2025, tests this idea in a large cloud platform deployment. It routes prompts across Claude models and reaches the quality of the strongest Claude model while reducing cost by 43.9%.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779714113420-b95d0e23-88fc-4f3c-ba16-15f58f4cb83d.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627055547-0fc1cf3a-e1e2-441e-9b56-24bb86a6e411.png)
 
 The open-source community is moving in the same direction. A GitHub Search API check in LiteLLM, one of the hottest model API routing projects, shows that routing terms related to cost, budget, and spend governance appear often in issues and PRs: 23 results for `cost based routing`, 18 for `lowest cost`, 37 for `budget routing`, and 76 for `spend tracking` as of May 22, 2026. Engineering teams are already asking: how do we route requests to models that are more suitable, cheaper, and easier to govern, while still keeping quality and stability?
 
 ## Trends and Project Stories
-
 Subtitle: Technical shifts also show up in how projects describe themselves.
 
 ### Description Signals: Projects Are Rewriting Their Self-Introductions
-
 Classifications and leaderboards reveal structure, but they can still feel abstract. Many more interesting changes are hidden in a project’s own description, and in the repeated “what we are not” lines in READMEs.
 
 After aligning historical landscape snapshots with current project data, we found that 96 out of 226 projects had changed their descriptions. The most visible new words include agent, harness, context, workflow, and MCP. These wording changes show projects looking for a new place in the ecosystem.
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627340812-4ef2d6b6-3e7d-4768-93b0-4feac4fb947b.png)
 
 These changes move toward the agent execution stack along several common paths.
 
 1. One common path is **Workflow Builder → Agent Orchestrator**. Projects such as Dify, Flowise, Langflow, and Activepieces used to answer the question “how do I build an LLM app or automation workflow?” Now they increasingly talk about agentic orchestration. `Deer-flow` is a sharp example. It used to describe itself as a community-driven Deep Research framework, with web search, crawling, and Python execution. Now it calls itself a long-horizon SuperAgent harness that can research, code, and create. Deep Research is moving from “help me look things up” to “execute long-running tasks.”
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/51756374/1779778608696-6bb9b65a-2502-4e01-94a3-8c02cf073a5f.png)
+
 
 2. Another path is **RAG / Data / Vector DB → Context / Memory Infra**. RAGFlow, Chroma, DataChain, and Letta show that RAG and data are growing beyond “adding knowledge to models.” They are becoming long-term context, memory layers, and searchable workbenches for agents. DataChain moves from ETL, analytics, and versioning to a context layer for unstructured data. Chroma moves from an embedding database to search infrastructure for AI. Letta moves from memory services to a platform for stateful agents. These are all part of the same hidden line.
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/51756374/1779775757834-eacd25ea-06b6-4603-9350-90353cbb95de.png)
+
 
 3. A third path is closer to the user entry point: **Chatbot / AI Client → Agent Workspace / Personal Assistant**. `lobehub/lobehub` is worth a closer look. Its old description called it Lobe Chat, a modern-design AI chat framework. Now it says users can find, build, and collaborate with agent teammates. Chatbot projects like LobeChat are actively escaping the name and imagination of the “chat box.” It is not just saying “we are also agents.” It is rewriting the product from Chat to Hub: from human-model conversation to humans living, working, and dividing tasks with agent teammates.
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/51756374/1779779119722-aeb08ea2-1469-4a50-8162-99f4c479899b.png)
+
 
 4. A path closer to developer tools is **Dev Tool / IDE / Terminal → Agentic Dev Environment**. Warp, Daytona, Coder, Continue, and Cline are turning developer tools into work environments for agents. Warp moves from an AI-powered terminal to an agentic development environment. Daytona moves from a dev environment manager to secure and elastic infrastructure for running AI-generated code. Continue moves from an AI code assistant to source-controlled AI checks and quality gates in CI. The shift is important: the software entry point is moving from “a person opens an IDE and writes code” to “a person defines the goal, and an agent executes in a controlled environment.”
 
+
+
 5. At the framework layer, many projects are moving from **Framework → Agent Harness**. LangChain, deepagents, Mastra, Agno, and Hive are no longer satisfied with calling themselves a framework or SDK. They are moving toward platform, harness, and production AI. `harness` is a meaningful word in this shift. Among the 96 projects that changed descriptions, six now contain `harness`, and four of those added it later, including deer-flow, LobeHub, and Hive.
+
+
 
 6. At the tool and gateway layer, the shift is **Tool Integration → Agent Control Plane**. Projects such as Composio, LiteLLM, and OpenSandbox push tool use beyond “function calling” or “API wrapper” toward something closer to a control plane. `ComposioHQ/composio` used to emphasize integrations and function calling. Now it says it powers 1,000+ toolkits, tool search, context management, authentication, and sandbox. It puts several key words of Agent Infra into one sentence.
 
-7. At the model infrastructure layer, we see **RL / Inference / Training → Agent Workload Infra**. AReaL, verl, SGLang, and GPustack show that Agentic AI is rewriting not only the application layer, but also Model Infra. `areal-project/AReaL` used to call itself a Distributed RL System for LLM Reasoning. Now it is “The RL Bridge for LLM-based Agent Applications.” Post-training is being redefined by agent tasks. It is not enough for a model to “answer correctly.” It also needs to get things done across tool use, long tasks, environment feedback, and multi-step decisions.
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/51756374/1779776084688-3a88a704-97f2-41a3-adb6-f9ade6b750a4.png)
+
+7. At the model infrastructure layer, we see **RL / Inference / Training → Agent Workload Infra**. AReaL, verl, SGLang, and GPustack show that Agentic AI is rewriting not only the application layer, but also Model Infra. `areal-project/AReaL` used to call itself a Distributed RL System for LLM Reasoning. Now it is “The RL Bridge for LLM-based Agent Applications.” Post-training is being redefined by agent tasks. It is not enough for a model to “answer correctly.” It also needs to get things done across tool use, long tasks, environment feedback, and multi-step decisions.
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627433930-73c48938-d03f-4f35-9c7c-d1f041efec1b.png)
 
 This kind of change can be misread as “everyone is just chasing the agent trend.” Some projects are doing that, of course. Every fast-growing ecosystem has this noise. But when a mature project changes its description, it often means the project has felt a real change in user demand.
 
 Agentic AI is pulling together projects that used to sit separately in applications, data, developer tools, MLOps, cloud native, and models. RAG projects talk about context. Data governance projects talk about semantic layers that agents can use. Development environments talk about developers and their agents. Gateway projects talk about model routing and cost control. Every project is asking: if my users are not only humans, but also agents, what should I provide?
 
 ### README Evidence: Projects Say What They Are Not
-
 Negative statements in READMEs give another kind of evidence. When a project keeps saying “not a...”, it is often not just explaining features. It is trying to escape the labels of the previous generation.
-
 ![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779164899057-bbc0e7db-33eb-43cf-9a7f-40f8951336b2.png)
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779718536690-c1f1f510-b7f0-40b6-b099-8c17432b9c69.png)
+
 
 OpenFang calls itself an Agent Operating System. It also clearly rejects labels like chatbot framework, Python wrapper around an LLM, and multi-agent orchestrator. The message is direct: chat windows, thin SDKs, and simple orchestration are no longer enough for the position it wants. It wants to sit at the OS or runtime layer.
 
@@ -204,18 +183,15 @@ Users are no longer satisfied with a nice chat page, a model API relay, or a dem
 This is the line between Agentic AI as a toy and Agentic AI in production.
 
 ## Developers and AI Tools
-
 Subtitle: The stronger AI tools become, the heavier human responsibility becomes.
 
 ### Who Is Taking Part in the Agentic AI Ecosystem?
-
 Before asking whether models will swallow software and open source, we should first look at how developers themselves are changing.
 
 We built a developer profile from 226 Agentic AI projects. We counted actors who participated in these projects from January 1 to before May 1, 2026, keeping bot and app accounts. This gave us 563,973 developers or automated accounts. We then ranked the Top 10,000 by their April 2026 `community_openrank` contribution in these projects and added GitHub profile, company, and location. About 2.0% are likely bot or app actors, or 198 automated accounts.
 
 Among these 10,000 high-contribution participants, 2,920 have identifiable company fields and 3,575 have standardized country fields. In self-reported companies, NVIDIA, Microsoft / GitHub, Intel, Google / DeepMind, and Red Hat rank high. In standardized countries, the United States has 1,113, China has 726, and India has 229. This is not a single group of “open-source hobbyists.” It is a network made of model companies, cloud vendors, chip companies, startups, university labs, independent developers, and automated accounts.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720116491-79cafb54-6f50-4bcb-8b9c-296830b6dc8f.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627508482-51724ee2-c645-4308-9d73-d3ab339f86c1.png)
 
 _Figure 11: The participant structure includes model companies, cloud vendors, chip companies, startups, open-source maintainers, independent developers, and automated accounts._
 
@@ -230,24 +206,20 @@ Third, the geography has not collapsed into a single Silicon Valley story. The U
 Automation is climbing up the software production chain step by step: first running tests, sending reports, and updating dependencies; then reading code, making suggestions, generating patches, and taking part in collaboration.
 
 There are two kinds of bots here. The first is traditional automation: `github-actions[bot]`, `dependabot[bot]`, `codecov[bot]`, `copybara-service[bot]`, and `pytorchmergebot`. They keep large engineering projects moving. The second is a new generation of AI tools: `greptile-apps[bot]`, `coderabbitai[bot]`, `gemini-code-assist[bot]`, and `chatgpt-codex-connector[bot]`. They have moved beyond fixed scripts. They read code, understand context, comment on changes, and join reviews.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720092581-74bc17b0-4296-4307-8ac5-3847e81e5cd9.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781628334060-07a0116e-8385-48b8-9f61-81b4da7863c1.png)
 
 _Figure 12: Bots are no longer just CI noise. Some already handle review, code understanding, automated fixes, and agent connector work._
 
 ### Carbon-Based Definers and Silicon-Based Executors
-
 The profile of real human developers is much richer than “programmers using AI to write code.” Top developers include independent tool builders, open-source maintainers, AI startup founders, engineers from cloud and model companies, researchers, tool authors, and community project maintainers. Some build agents. Some maintain inference and scheduling infrastructure. Some connect models to workflows. Some write rules, maintain communities, and handle issues and reviews.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720631986-e225bdb2-1faa-4a3c-9189-9e7f320d72d1.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627693711-54461f1a-0a0f-4c1f-9b64-fb206d74de40.png)
 
 Among the 226 Agentic AI projects we track, 78 are related to coding agents. They have 3.86 million stars in total, and 14,019 participants in April 2026. The **CLI-first path**, represented by Claude Code and Codex, enters local repos, shells, tests, and git directly. The **IDE-first path**, represented by Cursor, keeps the developer’s mental model and lets people step in at any time. Devin, OpenHands, and Multica represent **cowork / cloud worker** systems that try to move tasks from issue to PR in the background. Harness tools around memory and team orchestration try to give agents a long-term work environment.
 
 Leading projects are also using coding agents heavily. We scanned the file trees of the OpenRank Top 100 Agentic AI projects and found that 92 projects had at least one coding-agent-related configuration. On average, each project used 2.8 kinds. Claude Code had the highest coverage, at 81%. OpenAI Codex reached 69%.
 
 There is also a small but telling detail. In `google/adk-python`, the project with the most agent markers, the only agent config directory that remains is `.gemini`. But `.gitignore` still contains traces of Codex, Claude, Cursor, Windsurf, Aider, Cline, Continue, and other tools. Files like `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules` are like cheat sheets for AI. In the past, much project knowledge lived in maintainers’ heads: why this module should not be touched, which test is slowest, what to check before release, which dependency versions are tricky, and which changes require talking to someone first. In the agent era, if this hidden knowledge is not written down, agents cannot execute it reliably.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779720582970-ac4c8808-9bd1-4982-959a-0057ded95e26.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781628268156-23b40639-93ae-4df9-ac85-7042b4b7614e.png)
 
 This is symbolic. Open-source projects used to write `CONTRIBUTING.md` for human contributors. Now projects are starting to write onboarding documents for agent contributors. Open-source collaboration is no longer only an agreement among people. It is becoming a work protocol shared by humans and AI.
 
@@ -258,13 +230,11 @@ Software development is becoming “**carbon-based people define tasks, silicon-
 So the more common AI tools become, the more engineering organizations need to make rules, responsibility, and knowledge explicit. If a team has no tests, no docs, and no clear boundaries, agents will only amplify the mess. If a team has good modularity, runnable validation paths, and clear contribution rules, agents can become productivity multipliers.
 
 The same is true for individual developers. The scarce skill may no longer be “can you use an AI tool?” It will be whether you can turn fuzzy goals into executable tasks, turn a successful interaction into reusable rules, and see real risks in AI-generated plans. AI lowers the barrier to writing code. It does not lower the value of judgment. It lets more people enter software production, and it makes experienced developers’ knowledge look more like a system design capability.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779165506336-ecbb886e-1c7f-481e-9e01-4010af2c35a8.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781627941734-1a5c902a-746d-4802-ac0e-05240f8f86a4.png)
 
 _Figure 14: Developers do not disappear in the agentic era. They move from doing actions by hand to defining goals, constraining actions, and verifying results._
 
 ## Software Will Keep Being Rewritten, But Open Source Remains Irreplaceable
-
 In 2011, Marc Andreessen wrote “Software is eating the world.” Later, some people said open source was eating software, because open-source infrastructure became the default supply chain of modern software. **By 2026, a sharper question appeared: will models swallow software and open source?**
 
 The answer looks more like a new division of labor.
@@ -274,8 +244,7 @@ Models will take over some actions that used to be carried by software interface
 Software will not disappear. It may become more abundant, but it will not look exactly like before. The real change is that many software-use behaviors once done by humans will become model-driven action chains. Software companies may first become “agent-usable companies.” In the past, SaaS was built around UI, accounts, business data, and workflows. In the agent era, SaaS also needs stable APIs and machine-readable docs. Interfaces still matter, but UI is no longer the only entry point. Whoever can let agents safely work for users may become the new platform.
 
 Coding is only the first stop. The real world is messier and softer than code. Payments, finance, healthcare, government services, education, life services, and embodied intelligence all involve identity, responsibility, risk, regulation, trust, and human situations. For agents to enter these scenes, model capability is only the ticket. Institutions, products, and system design are the long race.
-
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779722948861-4e139872-20ca-4dfb-8ad5-5670e1d78367.png)
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781628026434-bbf5c3ad-f317-4647-8c74-c8743b116ff3.png)
 
 In 2025, the LLM developer ecosystem looked like a hackathon. Projects appeared quickly, became popular quickly, and disappeared quickly. By 2026, the **contest field is slowly turning into a construction site**.
 
@@ -286,23 +255,21 @@ In this process, open source will not win automatically. But it still has an irr
 Model companies can release stronger models. Cloud vendors can build larger AI factories. Application companies can make smoother closed-source products. <u>But what keeps an ecosystem healthy over the long term is still whether developers can participate, whether projects can be audited, whether standards can be built together, whether tools can be deployed locally, and whether knowledge can be shared.</u>
 
 ## Inclusive AGI: Intelligence Should Not Be a Privilege for the Few
-
 Ant’s path over the past twenty years has been answering similar questions. In online transactions, why did people not trust one another? Why was it hard for small merchants to get services? Could complex and expensive capabilities, once available only to a few, become easier, cheaper, and more accessible? Twenty years ago, we believed financial services should not be a privilege for the few. Today, facing AGI, we believe intelligence should not be a privilege for the few either.
 
 This may sound like a gentle slogan, but it is a hard judgment. The real world is much more complex than abstract problems. Math problems have standard answers. Code has tests. Games have rules. But services involve cost, trust, responsibility, emotion, compliance, regional differences, and people’s actual situations. A hospital appointment, an insurance claim, a small cross-border payment, or business advice for a small merchant cannot be solved simply by a higher benchmark.
 
 This is why Inclusion AI’s open AGI practice covers Model, Model Infra, Agent Infra, and AI Service at the same time. Models define the capability boundary. Post-training, inference, and training systems turn capability into infrastructure that can be supplied at scale. Agent Infra lets developers and domain experts connect models to real workflows. AI Service brings these capabilities into concrete fields such as finance, healthcare, and life services. Without systems, models are only demos of capability. Without tools, models have trouble entering industries. Without an open ecosystem, inclusion becomes only a rental right from a few platforms.
+![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1781628189192-9b2389f9-3ceb-4492-9faa-32e45b7555af.png)
 
-![](https://intranetproxy.alipay.com/skylark/lark/0/2026/png/85156528/1779723591647-465c2bb9-b3f8-4e82-b49d-a6d74721a0fa.png)
+
 
 Towards inclusive AGI is a simple but important hope: AI should not become a black box for a few people. It should not be only a productivity machine for large companies. It should be a public technology that more people can understand, use, change, and share.
 
 This can be reduced to three words: Available, Affordable, Inclusive.
 
 + Available means models and tools should be as open as possible, so developers, researchers, domain experts, and small or mid-sized organizations can access them, understand them, and adapt them. Open weights, data tools, inference engines, and agent protocols all lower the barrier. If intelligence is to become infrastructure, more people must be able to inspect it, adapt it, and improve it together.
-
 + Affordable means AI must really enter vertical scenarios: healthcare, finance, government services, education, public good, rural areas, and small businesses, not only premium subscriptions. The hard part is not making AI solve beautiful benchmark problems. The hard part is helping an older person book a hospital appointment, helping a small merchant run a business, or helping an ordinary family handle daily services at low enough cost.
-
 + Inclusive means the value of AI should not be captured only by large token consumers or a few platforms. Developers, open-source maintainers, data contributors, domain experts, and ordinary users should all have a place in the ecosystem. We need to respect real workflows and human experience, and let that experience compound through open collaboration into reusable tools and systems, instead of one-way releases.
 
 Towards inclusive AGI does not mean everyone must become a model company. It does not mean everyone must write low-level frameworks. It is a simple but important hope: **AI should not become a black box for the few. It should not be only a productivity machine for large companies. It should be a public technology that more people can understand, use, change, and share.**
@@ -310,8 +277,7 @@ Towards inclusive AGI does not mean everyone must become a model company. It doe
 This may be the most important job for open source in the AGI era.
 
 ## Notes on Data Scope
-
-The data mainly comes from the [Agentic AI landscape](https://github.com/antgroup/agentic-ai-landscape/blob/main/data/2605_agentic_projects.csv) repository, OpenDigger, GitHub API, Hugging Face Hub, OpenRouter public leaderboards, and searches across releases, issues, PRs, and GitHub Search API results for projects such as vLLM, SGLang, TensorRT-LLM, llama.cpp, Dynamo, and LiteLLM.
+The data mainly comes from the [Agentic AI landscape](https://github.com/antgroup/agentic-ai-landscape/blob/main/data/agentic-ai-projects.csv) repository, OpenDigger, GitHub API, Hugging Face Hub, OpenRouter public leaderboards, and searches across releases, issues, PRs, and GitHub Search API results for projects such as vLLM, SGLang, TensorRT-LLM, llama.cpp, Dynamo, and LiteLLM.
 
 Agentic AI project trend data uses the April 2026 OpenRank scope. The developer profile covers activity from January 1, 2026 to before May 1, 2026, and keeps bot and app actors.
 

--- a/scripts/build_developer_profiles.py
+++ b/scripts/build_developer_profiles.py
@@ -1,8 +1,8 @@
 """Build GitHub developer profile CSVs for a project set.
 
 The script reads a project CSV with a ``repo_id`` column, ranks developers by
-their monthly ``community_openrank`` contribution within those repositories,
-and enriches the Top N with ClickHouse ``gh_user_info`` plus optional GitHub API
+their monthly or period OpenRank contribution within those repositories, and
+enriches the Top N with ClickHouse ``gh_user_info`` plus optional GitHub API
 fallback when ClickHouse has no profile row for a user.
 """
 
@@ -12,7 +12,9 @@ import argparse
 import csv
 import json
 import os
+import re
 import time
+from collections import Counter
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -26,7 +28,7 @@ BASE = Path(__file__).resolve().parents[1]
 ENV_PATH = BASE / "scripts" / ".env"
 DEFAULT_INPUT_CSV = BASE / "data" / "agentic-ai-projects.csv"
 
-load_dotenv(ENV_PATH)
+load_dotenv(ENV_PATH, override=True)
 
 
 def bypass_local_proxy_for_hosts(*hosts: str) -> None:
@@ -39,9 +41,7 @@ def bypass_local_proxy_for_hosts(*hosts: str) -> None:
         os.environ[key] = ",".join(existing)
 
     for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"):
-        value = os.getenv(key, "")
-        if "127.0.0.1" in value or "localhost" in value:
-            os.environ.pop(key, None)
+        os.environ.pop(key, None)
 
 
 def get_client():
@@ -72,6 +72,15 @@ def add_months(month: date, months: int) -> date:
     year = month.year + (month.month - 1 + months) // 12
     new_month = (month.month - 1 + months) % 12 + 1
     return date(year, new_month, 1)
+
+
+def month_sequence(start: date, end_exclusive: date) -> list[date]:
+    months = []
+    current = date(start.year, start.month, 1)
+    while current < end_exclusive:
+        months.append(current)
+        current = add_months(current, 1)
+    return months
 
 
 def q(s: str) -> str:
@@ -105,7 +114,7 @@ def read_repo_ids(input_csv: Path) -> list[int]:
 
 
 def describe_tables(client) -> None:
-    for table in ("events", "community_openrank", "gh_user_info", "location_info"):
+    for table in ("events", "community_openrank", "normalized_community_openrank", "gh_user_info", "location_info"):
         print(f"\n--- opensource.{table} ---")
         result = client.query(f"DESCRIBE TABLE opensource.{table}")
         for row in result.result_rows:
@@ -143,29 +152,106 @@ def profile_value(profile: dict[str, Any], candidates: list[str]) -> Any:
     return ""
 
 
+BOT_LOGIN_RE = re.compile(
+    r"(\[bot\]$|bot$|^bot-|(^|[-_])bot([-_]|$)|^app/|github-actions|dependabot|renovate|"
+    r"coderabbit|codecov|sonarcloud|pre-commit-ci|stale|vercel|netlify|"
+    r"cicd|(^|[-_])ci([-_]|$)|robot-?ci|jenkins|buildkite|automation|"
+    r"automated|actions$|^actions[-_]|mergebot|merge-bot|release-bot|cla-assistant)",
+    re.IGNORECASE,
+)
+
+
+def bot_reason(login: str, profile: dict[str, Any] | None = None) -> str:
+    if BOT_LOGIN_RE.search(login or ""):
+        return "login_pattern"
+    profile = profile or {}
+    status = str(profile.get("status") or "").lower()
+    if status == "bot":
+        return "profile_status"
+    return ""
+
+
+def as_json_array(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(list(value), ensure_ascii=False)
+    except TypeError:
+        return json.dumps(value, ensure_ascii=False)
+
+
+def social_accounts_by_provider(names: Any, providers: Any) -> tuple[dict[str, str], str]:
+    if not names or not providers:
+        return {}, ""
+    try:
+        names_list = list(names)
+        providers_list = list(providers)
+    except TypeError:
+        return {}, ""
+
+    grouped: dict[str, list[str]] = {}
+    other: list[str] = []
+    for provider, name in zip(providers_list, names_list):
+        provider_key = str(provider or "").strip().lower()
+        account = str(name or "").strip()
+        if not provider_key or not account:
+            continue
+        if provider_key in {"twitter", "linkedin"}:
+            grouped.setdefault(provider_key, [])
+            if account not in grouped[provider_key]:
+                grouped[provider_key].append(account)
+        else:
+            item = f"{provider_key}: {account}"
+            if item not in other:
+                other.append(item)
+
+    flattened = {provider: "; ".join(accounts) for provider, accounts in grouped.items()}
+    return flattened, "; ".join(other)
+
+
+def openrank_int(value: Any) -> int:
+    return int(round(float(value or 0)))
+
+
 def build_outputs(
     client,
     input_csv: Path,
     output_csv: Path,
-    openrank_month: date,
+    openrank_month: date | None,
     period_start: date,
     period_end: date,
     limit: int,
     include_bots: bool,
     use_github_fallback: bool,
+    openrank_table: str,
 ) -> dict[str, Any]:
     repo_ids = read_repo_ids(input_csv)
     if not repo_ids:
         raise RuntimeError(f"No repo_id values found in {input_csv}")
 
     repo_ids_sql = ", ".join(str(repo_id) for repo_id in repo_ids)
-    openrank_date = openrank_month.strftime("%Y-%m-01")
-    suffix = openrank_month.strftime("%y%m")
-    openrank_field = f"openrank_{suffix}"
-    top_repo_field = f"top_repo_name_{suffix}"
-    top_repo_openrank_field = f"top_repo_openrank_{suffix}"
-    bot_filter = "" if include_bots else "AND c.actor_login NOT LIKE '%[bot]' AND c.actor_login NOT LIKE '%bot'"
-    event_bot_filter = "" if include_bots else "AND actor_login NOT LIKE '%[bot]' AND actor_login NOT LIKE '%bot'"
+    months = month_sequence(period_start, period_end)
+    if not months:
+        raise RuntimeError("period-start must be earlier than period-end")
+    suffix = f"{months[0].strftime('%y%m')}_{months[-1].strftime('%y%m')}"
+    openrank_total_field = f"openrank_total_{suffix}"
+    month_fields = [f"openrank_{month.strftime('%y%m')}" for month in months]
+    bot_sql_pattern = (
+        "(\\\\[bot\\\\]$|bot$|^bot-|(^|[-_])bot([-_]|$)|^app/|github-actions|dependabot|renovate|"
+        "coderabbit|codecov|sonarcloud|pre-commit-ci|stale|vercel|netlify|"
+        "cicd|(^|[-_])ci([-_]|$)|robot-?ci|jenkins|buildkite|automation|"
+        "automated|actions$|^actions[-_]|mergebot|merge-bot|release-bot|cla-assistant)"
+    )
+    bot_filter = "" if include_bots else (
+        "AND NOT match(lower(c.actor_login), "
+        f"'{bot_sql_pattern}')"
+    )
+    event_bot_filter = "" if include_bots else (
+        "AND NOT match(lower(actor_login), "
+        f"'{bot_sql_pattern}')"
+    )
 
     gh_cols = table_columns(client, "gh_user_info")
     loc_cols = table_columns(client, "location_info")
@@ -183,53 +269,85 @@ def build_outputs(
     """
     total_developers = client.command(total_developers_sql)
 
+    yyyymm_expr = "c.yyyymm" if openrank_table == "normalized_community_openrank" else "toYYYYMM(c.created_at)"
+    month_selects = []
+    for month, field in zip(months, month_fields):
+        yyyymm = month.year * 100 + month.month
+        month_selects.append(f"round(sumIf(repo_month_openrank, yyyymm = {yyyymm}), 6) AS {field}")
+    month_select_sql = ",\n                ".join(month_selects)
+    final_month_select_sql = ",\n            ".join(f"m.{field} AS {field}" for field in month_fields)
+    candidate_limit = int(limit if include_bots else limit * 3)
     top_sql = f"""
         WITH
-        actor_repo AS (
+        actor_repo_month AS (
             SELECT
                 c.actor_id,
                 any(c.actor_login) AS actor_login,
                 c.repo_id,
                 any(c.repo_name) AS repo_name,
-                sum(c.openrank) AS repo_openrank
-            FROM opensource.community_openrank c
+                {yyyymm_expr} AS yyyymm,
+                sum(c.openrank) AS repo_month_openrank
+            FROM opensource.{openrank_table} c
             WHERE c.platform = 'GitHub'
-              AND c.created_at = '{openrank_date}'
+              AND c.created_at >= '{period_start.isoformat()}'
+              AND c.created_at < '{period_end.isoformat()}'
               AND c.repo_id IN ({repo_ids_sql})
               AND c.actor_id != 0
               {bot_filter}
-            GROUP BY c.actor_id, c.repo_id
+            GROUP BY c.actor_id, c.repo_id, yyyymm
+        ),
+        actor_repo AS (
+            SELECT
+                actor_id,
+                any(actor_login) AS actor_login,
+                repo_id,
+                any(repo_name) AS repo_name,
+                sum(repo_month_openrank) AS repo_openrank
+            FROM actor_repo_month
+            GROUP BY actor_id, repo_id
         ),
         actor_total AS (
             SELECT
                 actor_id,
                 any(actor_login) AS actor_login,
-                sum(repo_openrank) AS openrank
+                round(sum(repo_openrank), 6) AS openrank_total,
+                countDistinct(repo_id) AS repo_count
             FROM actor_repo
+            GROUP BY actor_id
+        ),
+        actor_month AS (
+            SELECT
+                actor_id,
+                {month_select_sql},
+                countDistinct(yyyymm) AS active_months
+            FROM actor_repo_month
             GROUP BY actor_id
         ),
         top_repo AS (
             SELECT
                 actor_id,
                 argMax(repo_name, repo_openrank) AS top_repo_name,
-                max(repo_openrank) AS top_repo_openrank
+                round(max(repo_openrank), 6) AS top_repo_openrank_total
             FROM actor_repo
             GROUP BY actor_id
         )
         SELECT
-            a.actor_id,
-            a.actor_login,
-            round(a.openrank, 6) AS openrank,
-            r.top_repo_name,
-            round(r.top_repo_openrank, 6) AS top_repo_openrank
+            a.actor_id AS actor_id,
+            a.actor_login AS actor_login,
+            a.openrank_total AS openrank_total,
+            {final_month_select_sql},
+            a.repo_count AS repo_count,
+            r.top_repo_name AS top_repo_name,
+            r.top_repo_openrank_total AS top_repo_openrank_total
         FROM actor_total a
+        LEFT JOIN actor_month m ON a.actor_id = m.actor_id
         LEFT JOIN top_repo r ON a.actor_id = r.actor_id
-        ORDER BY a.openrank DESC
-        LIMIT {int(limit)}
+        ORDER BY a.openrank_total DESC
+        LIMIT {candidate_limit}
     """
     top_rows = list(client.query(top_sql).named_results())
     actor_ids = [int(row["actor_id"]) for row in top_rows]
-    print(f"Fetched top {len(actor_ids)} developers by {openrank_month.strftime('%Y-%m')} community OpenRank")
+    print(f"Fetched top {len(actor_ids)} developers by {period_start.isoformat()}..{period_end.isoformat()} {openrank_table}")
 
     profile_by_id: dict[int, dict[str, Any]] = {}
     if actor_ids:
@@ -248,6 +366,10 @@ def build_outputs(
     loc_key_col = first_existing(loc_cols, ["location", "raw_location", "input", "query", "name"])
     loc_city_col = first_existing(loc_cols, ["city", "standard_city", "normalized_city", "locality"])
     loc_country_col = first_existing(loc_cols, ["country", "standard_country", "country_name"])
+    loc_admin1_col = first_existing(loc_cols, ["administrative_area_level_1"])
+    loc_admin2_col = first_existing(loc_cols, ["administrative_area_level_2"])
+    loc_longitude_col = first_existing(loc_cols, ["longitude"])
+    loc_latitude_col = first_existing(loc_cols, ["latitude"])
     normalized_by_location: dict[str, dict[str, Any]] = {}
     raw_locations = sorted(
         {
@@ -284,6 +406,9 @@ def build_outputs(
         actor_id = int(row["actor_id"])
         login = row["actor_login"]
         profile = profile_by_id.get(actor_id, {})
+        reason = bot_reason(str(login), profile)
+        if reason and not include_bots:
+            continue
         source = "clickhouse" if profile else ""
 
         location = profile_value(profile, ["location"])
@@ -292,6 +417,11 @@ def build_outputs(
         company = profile_value(profile, ["company"])
         name = profile_value(profile, ["name", "login"])
         github_created_at = profile_value(profile, ["created_at", "createdAt"])
+        profile_updated_at = profile_value(profile, ["updated_at", "updatedAt"])
+        twitter_username = profile_value(profile, ["twitter_username"])
+        social_names = profile_value(profile, ["social_accounts.name"])
+        social_providers = profile_value(profile, ["social_accounts.provider"])
+        social_fields, social_other = social_accounts_by_provider(social_names, social_providers)
 
         if use_github_fallback and not profile:
             gh_user = fetch_github_user(str(login), session, gh_headers)
@@ -304,44 +434,75 @@ def build_outputs(
                 company = gh_user.get("company") or ""
                 name = gh_user.get("name") or ""
                 github_created_at = gh_user.get("created_at") or ""
+                profile_updated_at = gh_user.get("updated_at") or ""
+                twitter_username = gh_user.get("twitter_username") or ""
                 if github_fallback_count % 50 == 0:
                     time.sleep(2)
 
         loc_row = normalized_by_location.get(str(location).strip(), {}) if location else {}
-        output_rows.append(
+        out = {
+            "rank": len(output_rows) + 1,
+            "actor_id": actor_id,
+            "actor_login": login,
+            openrank_total_field: openrank_int(row["openrank_total"]),
+            "monthly_openrank": json.dumps(
+                [openrank_int(row.get(field)) for field in month_fields],
+                ensure_ascii=False,
+            ),
+        }
+        twitter = twitter_username or social_fields.get("twitter", "")
+        out.update(
             {
-                "actor_id": actor_id,
-                "actor_login": login,
-                openrank_field: row["openrank"],
-                top_repo_field: row["top_repo_name"],
-                top_repo_openrank_field: row["top_repo_openrank"],
-                "location": location,
+                "repo_count": row.get("repo_count", ""),
+                "top_repo_name": row["top_repo_name"],
+                "top_repo_openrank_total": openrank_int(row["top_repo_openrank_total"]),
+                "name": name,
+                "company": company,
+                "email": email,
+                "twitter": twitter,
+                "linkedin": social_fields.get("linkedin", ""),
+                "other_social_accounts": social_other,
+                "blog": profile_value(profile, ["blog"]),
                 "standard_city": loc_row.get(loc_city_col) if loc_city_col else "",
                 "standard_country": loc_row.get(loc_country_col) if loc_country_col else "",
                 "bio": bio,
-                "email": email,
-                "company": company,
-                "name": name,
-                "created_at": github_created_at,
+                "github_created_at": github_created_at,
+                "github_updated_at": profile_updated_at,
                 "profile_source": source or "missing",
+                "is_likely_bot": bool(reason),
+                "bot_reason": reason,
             }
         )
+        output_rows.append(
+            out
+        )
+        if len(output_rows) >= limit:
+            break
 
     fieldnames = [
+        "rank",
         "actor_id",
         "actor_login",
-        openrank_field,
-        top_repo_field,
-        top_repo_openrank_field,
-        "location",
+        openrank_total_field,
+        "monthly_openrank",
+        "repo_count",
+        "top_repo_name",
+        "top_repo_openrank_total",
+        "name",
+        "company",
+        "email",
+        "twitter",
+        "linkedin",
+        "other_social_accounts",
+        "blog",
         "standard_city",
         "standard_country",
         "bio",
-        "email",
-        "company",
-        "name",
-        "created_at",
+        "github_created_at",
+        "github_updated_at",
         "profile_source",
+        "is_likely_bot",
+        "bot_reason",
     ]
     output_csv.parent.mkdir(parents=True, exist_ok=True)
     with output_csv.open("w", newline="", encoding="utf-8") as f:
@@ -349,17 +510,27 @@ def build_outputs(
         writer.writeheader()
         writer.writerows(output_rows)
 
+    country_counts = Counter(str(row.get("standard_country") or "").strip() for row in output_rows if row.get("standard_country"))
+    city_counts = Counter(str(row.get("standard_city") or "").strip() for row in output_rows if row.get("standard_city"))
     summary: dict[str, Any] = {
         "input_csv": relative_or_absolute(input_csv),
         "output_csv": relative_or_absolute(output_csv),
         "repo_count": len(repo_ids),
         "period": {"start": period_start.isoformat(), "end_exclusive": period_end.isoformat()},
+        "openrank_table": openrank_table,
         "include_bots": include_bots,
         "developer_count_in_period": total_developers,
-        "openrank_month": openrank_month.strftime("%Y-%m"),
         "top_developer_limit": limit,
         "top_developer_rows": len(output_rows),
         "github_fallback_count": github_fallback_count,
+        "missing_email": sum(1 for row in output_rows if not row.get("email")),
+        "missing_bio": sum(1 for row in output_rows if not row.get("bio")),
+        "missing_standard_location": sum(
+            1 for row in output_rows if not row.get("standard_country") and not row.get("standard_city")
+        ),
+        "standardized_location_rows": sum(1 for row in output_rows if row.get("standard_country") or row.get("standard_city")),
+        "top_countries": country_counts.most_common(20),
+        "top_cities": city_counts.most_common(20),
         "profile_sources": {},
         "location_join": {
             "location_info_key": loc_key_col,
@@ -382,16 +553,18 @@ def main() -> None:
     parser.add_argument("--schema", action="store_true", help="Print ClickHouse table schemas and exit.")
     parser.add_argument("--input-csv", type=Path, default=DEFAULT_INPUT_CSV, help="Project CSV with repo_id.")
     parser.add_argument("--output-csv", type=Path, help="Output developer profile CSV.")
-    parser.add_argument("--openrank-month", type=parse_month, default=default_month, help="YYYY-MM month for community_openrank.")
+    parser.add_argument("--openrank-month", type=parse_month, default=None, help="Legacy single month hint. Period ranking is controlled by --period-start/--period-end.")
+    parser.add_argument("--openrank-table", default="community_openrank", choices=["community_openrank", "normalized_community_openrank"])
     parser.add_argument("--period-start", type=lambda v: datetime.strptime(v, "%Y-%m-%d").date(), default=default_period_start)
     parser.add_argument("--period-end", type=lambda v: datetime.strptime(v, "%Y-%m-%d").date(), default=default_period_end)
     parser.add_argument("--limit", type=int, default=1000, help="Number of developers to output.")
     parser.add_argument("--exclude-bots", action="store_true", help="Exclude bot-looking logins.")
     parser.add_argument("--no-github-fallback", action="store_true", help="Do not call GitHub API for users missing in gh_user_info.")
+    parser.add_argument("--summary-json", type=Path, help="Optional JSON summary output path.")
     args = parser.parse_args()
 
     input_csv = args.input_csv if args.input_csv.is_absolute() else BASE / args.input_csv
-    output_csv = args.output_csv if args.output_csv else default_output_path(input_csv, args.openrank_month, args.limit)
+    output_csv = args.output_csv if args.output_csv else default_output_path(input_csv, args.openrank_month or default_month, args.limit)
     if not output_csv.is_absolute():
         output_csv = BASE / output_csv
 
@@ -410,7 +583,12 @@ def main() -> None:
         limit=args.limit,
         include_bots=not args.exclude_bots,
         use_github_fallback=not args.no_github_fallback,
+        openrank_table=args.openrank_table,
     )
+    if args.summary_json:
+        summary_json = args.summary_json if args.summary_json.is_absolute() else BASE / args.summary_json
+        summary_json.parent.mkdir(parents=True, exist_ok=True)
+        summary_json.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     print(json.dumps(summary, indent=2, ensure_ascii=False))
 
 


### PR DESCRIPTION
## Summary
- Update the English Agentic AI article with refreshed image links and data-scope wording
- Extend developer profile generation to support period OpenRank totals, monthly columns, bot detection, and richer social/profile fields
- Keep the article data link aligned with `data/agentic-ai-projects.csv`

## Validation
- `git diff --check`
- `.venv/bin/python -c "import py_compile; py_compile.compile('scripts/build_developer_profiles.py', cfile='/tmp/build_developer_profiles.pyc', doraise=True); print('py_compile ok')"`